### PR TITLE
Adding depth field to views

### DIFF
--- a/bricks.module
+++ b/bricks.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Render\Element;
 use Drupal\Core\TypedData\DataDefinition;
+use Drupal\Component\Utility\Html;
 
 /* BRICKS STORAGE */
 
@@ -78,6 +79,9 @@ function _bricks_nest_items($element, $items) {
     $items[$delta]['#label'] = $element['#items'][$delta]->entity->label();
     $items[$delta]['#delta'] = $delta;
     $items[$delta]['#parent_delta'] = $parents[0];
+    $items[$delta]['#attributes']['class'][] = 'brick';
+    $items[$delta]['#attributes']['class'][] = 'brick--type--' . Html::cleanCssIdentifier($element['#items'][$delta]->entity->bundle());
+    $items[$delta]['#attributes']['class'][] = 'brick--id--' . $element['#items'][$delta]->entity->id();
 
     $items[$delta]['childs'] = [];
     if (!empty($element['#items'][$delta]->options['view_mode'])) {

--- a/bricks.module
+++ b/bricks.module
@@ -40,6 +40,20 @@ function _bricks_field_schema_alter(&$schema) {
   ];
 }
 
+
+/**
+ * Implements hook_views_data_alter().
+ */
+
+function bricks_field_views_data_alter(array &$data, \Drupal\field\FieldStorageConfigInterface $field_storage) {
+  if($field_storage->getType() == 'bricks') {
+    $field_name = $field_storage->getName();
+    foreach($data as &$item) {
+      $item[$field_name . '_depth']['field']['id'] = 'bricksdepth';
+    }
+  }
+}
+
 /* BRICKS FORMATTING */
 
 /**

--- a/src/Plugin/views/field/BricksDepth.php
+++ b/src/Plugin/views/field/BricksDepth.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\bricks\Plugin\views\field;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+
+/**
+ * @ingroup views_field_handlers
+ *
+ * @ViewsField("bricksdepth")
+ */
+class BricksDepth extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+    $options['style'] = ['default' => ''];
+    $options['prefix'] = ['default' => ''];
+    $options['suffix'] = ['default' => ''];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    $form['style'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Style'),
+      '#options' => [
+        '' => $this->t('Raw value'),
+        'space' => $this->t('Spaces'),
+        'line' => $this->t('Lines'),
+        'tree' => $this->t('Tree'),
+      ],
+      '#default_value' => $this->options['style'],
+    ];
+    $form['prefix'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Prefix'),
+      '#default_value' => $this->options['prefix'],
+      '#description' => $this->t('Text to put before the number, such as currency symbol.'),
+    ];
+    $form['suffix'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Suffix'),
+      '#default_value' => $this->options['suffix'],
+      '#description' => $this->t('Text to put after the number, such as currency symbol.'),
+    ];
+    parent::buildOptionsForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $raw_value = $this->getValue($values);
+
+    switch($this->options['style']) {
+      case 'space':
+        $indentation = [
+          '#theme' => 'indentation',
+          '#size' => $raw_value,
+        ];
+        $value =\Drupal::service('renderer')->render($indentation);
+        break;
+      case 'tree':
+        if($raw_value > 0) 
+          $value = '&nbsp;&nbsp;' . str_repeat('&nbsp;', ($raw_value - 1) * 4) . '└';
+        else 
+          $value = '';
+        break;
+      case 'line':
+        $value = '└' . str_repeat('─', $raw_value);
+        break;
+      default:
+        $value = $raw_value;
+        break;
+    }
+
+    return [
+      '#markup' =>
+        $this->sanitizeValue($this->options['prefix'], 'xss')
+        . $value
+        . $this->sanitizeValue($this->options['suffix'], 'xss'),
+    ];
+  }
+
+//   /**
+//    * {@inheritdoc}
+//    */
+//   public function clickSort($order) {
+//     $this->query->addOrderBy('node_field_data', 'created', $order);
+//   }
+// 
+}


### PR DESCRIPTION
Make depth field available in views field list, and BrickDepth field formatter, that can render this field as identation, tree symbols and lines.